### PR TITLE
Optimized implementation using topological sort

### DIFF
--- a/src/NovoNordisk.CriticalPath/CriticalPathMethod.cs
+++ b/src/NovoNordisk.CriticalPath/CriticalPathMethod.cs
@@ -1,7 +1,10 @@
-﻿using NovoNordisk.CriticalPath.Exceptions;
+using NovoNordisk.CriticalPath.Exceptions;
 
 namespace NovoNordisk.CriticalPath;
 
+/// <summary>
+/// Interface for the Critical Path Method.
+/// </summary>
 public interface ICriticalPathMethod
 {
     /// <summary>
@@ -10,7 +13,7 @@ public interface ICriticalPathMethod
     /// <param name="activities">List of activities. Note that the HashSet is call-by-reference, so its properties will be modified by this function.</param>
     /// <returns>The activities on the critical path, ordered by their dependencies.</returns>
     List<Activity> Execute(HashSet<Activity> activities);
-}
+}   
 
 /// <summary>
 /// Implementation of the Critical Path Method.
@@ -22,117 +25,128 @@ public class CriticalPathMethod : ICriticalPathMethod
     /// </summary>
     /// <param name="activities">List of activities. Note that the HashSet is call-by-reference, so its properties will be modified by this function.</param>
     /// <returns>The activities on the critical path, ordered by their dependencies.</returns>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Should be none-static so users can mock the usage in tests.")]
     public List<Activity> Execute(HashSet<Activity> activities)
     {
-        CalculateCriticalCost(activities);
-        CalculateLatest(activities);
-        var initialActivities = ActivitiesWithNoPredecessors(activities);
-        CalculateEarly(initialActivities);
-        var criticalActivities = CriticalActivities(initialActivities);
+        var edges = GetEdges(activities);
+        var sortedActivities = TopologicalSort(activities, edges);
+        CalculateCosts(sortedActivities, edges);
+        var criticalActivities = CriticalActivities(activities, edges);
+
         return criticalActivities;
     }
-
-    // TODO: This could probably be re-written to a recursive function so we could get rid of the while loop
-    // If there is a loop in the graph then this will keep looping forever. But we checked this earlier.
-    private static List<Activity> CriticalActivities(HashSet<Activity> initialActivities)
+    
+    private static HashSet<Tuple<Activity, Activity>> GetEdges(HashSet<Activity> activities)
     {
+        var edges = new HashSet<Tuple<Activity, Activity>>();
+        var visited = new HashSet<Activity>();
+        
+        foreach (var activity in activities)
+        {
+            AddEdgesFromActivity(activity, edges, visited);
+        }
+        
+        return edges;
+    }
+
+    private static void AddEdgesFromActivity(Activity activity, HashSet<Tuple<Activity, Activity>> edges, HashSet<Activity> visited)
+    {
+        if (!visited.Add(activity))
+        {
+            return;
+        }
+
+        foreach (var dependency in activity.Dependencies)
+        {
+            edges.Add(new Tuple<Activity, Activity>(activity, dependency));
+            AddEdgesFromActivity(dependency, edges, visited);
+        }
+    }
+    
+    private static List<Activity> TopologicalSort(HashSet<Activity> nodes, HashSet<Tuple<Activity, Activity>> inputEdges)
+    {
+        var activities = new List<Activity>();
+        var edges = new HashSet<Tuple<Activity, Activity>>(inputEdges);
+        var startingNodes = new HashSet<Activity>(nodes.Where(n => edges.All(e => e.Item2.Equals(n) == false)));
+        
+        while (startingNodes.Any())
+        {
+            var node = startingNodes.First();
+            startingNodes.Remove(node);
+            
+            activities.Add(node);
+            
+            foreach (var edge in edges.Where(e => e.Item1.Equals(node)).ToList())
+            {
+                var activity = edge.Item2;
+                edges.Remove(edge);
+                
+                if (edges.All(me => me.Item2.Equals(activity) == false))
+                {
+                    startingNodes.Add(activity);
+                }
+            }
+        }
+        
+        if (edges.Any())
+        {
+            throw new CyclicDependencyException("There is a cyclic dependency in the graph. A critical path cannot be determined");
+        }
+
+        return activities;
+    }
+
+    private static void CalculateCosts(IList<Activity> activities, HashSet<Tuple<Activity, Activity>> edges)
+    {
+        foreach (var activity in activities)
+        {
+            var edgesToActivity = edges.Where(e => e.Item2.Equals(activity)).ToList();
+            
+            var completionTime = edgesToActivity
+                .Select(e => e.Item1.EarlyFinish)
+                .DefaultIfEmpty(0)
+                .Max();
+            
+            activity.EarlyStart = completionTime;
+            activity.EarlyFinish = completionTime + activity.Cost;
+        }
+
+        foreach (var activity in activities.Reverse())
+        {
+            var critical = activity.Dependencies
+                .Select(remainingActivityDependency => remainingActivityDependency.CriticalCost)
+                .DefaultIfEmpty(0)
+                .Max();
+
+            activity.CriticalCost = critical + activity.Cost;
+        }
+        
+        var criticalPathMaxCost = activities.Select(activity => activity.CriticalCost).Max();
+        foreach (var activity in activities.Reverse())
+        {
+            var edgesFromActivity = edges.Where(e => e.Item1.Equals(activity)).ToList();
+
+            var latestFinish = edgesFromActivity
+                .Select(e => e.Item2.LatestStart)
+                .DefaultIfEmpty(criticalPathMaxCost)
+                .Min();
+
+            activity.LatestFinish = latestFinish;
+            activity.LatestStart = latestFinish - activity.Cost;
+        }
+    }
+    
+    private static List<Activity> CriticalActivities(HashSet<Activity> nodes, HashSet<Tuple<Activity, Activity>> edges)
+    {
+        var startingNodes = new HashSet<Activity>(nodes.Where(n => edges.All(e => e.Item2.Equals(n) == false)));
         var criticalActivities = new List<Activity>();
 
-        var nextActivity = initialActivities.First(_ => _.TotalFloat == 0);
+        var nextActivity = startingNodes.First(n => n.TotalFloat == 0);
         while (nextActivity != null)
         {
             criticalActivities.Add(nextActivity);
-            nextActivity = nextActivity.Dependencies.FirstOrDefault(_ => _.TotalFloat == 0);
+            nextActivity = nextActivity.Dependencies.FirstOrDefault(n => n.TotalFloat == 0);
         }
 
         return criticalActivities;
-    }
-
-    private static void CalculateCriticalCost(HashSet<Activity> activities)
-    {
-        var completed = new HashSet<Activity>(); // Activities whose critical cost has been calculated
-        var remaining = new HashSet<Activity>(activities); // Activities whose critical cost needs to be calculated
-
-        while (remaining.Any())
-        {
-            var progress = false;
-            foreach (var remainingActivity in remaining)
-            {
-                //If all dependencies are completed (have a critical cost calculated) then we can complete this activity too
-                var dependenciesNotCompleted = remainingActivity.Dependencies.Where(_ => !completed.Contains(_));
-                if (dependenciesNotCompleted.Any())
-                {
-                    //Not all dependencies are completed, so move on to the next activity
-                    continue;
-                }
-
-                var critical = 0;
-                foreach (var remainingActivityDependency in remainingActivity.Dependencies)
-                {
-                    if (remainingActivityDependency.CriticalCost > critical)
-                    {
-                        critical = remainingActivityDependency.CriticalCost;
-                    }
-                }
-
-                remainingActivity.CriticalCost = critical + remainingActivity.Cost;
-
-                completed.Add(remainingActivity);
-                remaining.Remove(remainingActivity);
-                progress = true;
-            }
-
-            // If we haven't made any progress then a cycle must exist in the graph and we wont be able to calculate the critical path
-            if (!progress)
-            {
-                throw new CyclicDependencyException(
-                    "There is a cyclic dependency in the graph. A critical path cannot be determined");
-            }
-        }
-    }
-
-    private static void CalculateLatest(HashSet<Activity> activities)
-    {
-        var criticalPathMaxCost = activities.Select(activity => activity.CriticalCost).Max();
-        foreach (var activity in activities)
-        {
-            activity.LatestStart = criticalPathMaxCost - activity.CriticalCost;
-            activity.LatestFinish = activity.LatestStart + activity.Cost;
-        }
-    }
-
-    private static HashSet<Activity> ActivitiesWithNoPredecessors(IReadOnlyCollection<Activity> activities)
-    {
-        var allSuccessors = activities.SelectMany(_ => _.Dependencies).Distinct();
-
-        var activitiesWithNoPredecessors = new HashSet<Activity>(activities);
-        activitiesWithNoPredecessors.ExceptWith(allSuccessors);
-
-        return activitiesWithNoPredecessors;
-    }
-
-    private static void CalculateEarly(HashSet<Activity> initialActivities)
-    {
-        foreach (var initialActivity in initialActivities)
-        {
-            initialActivity.EarlyStart = 0;
-            initialActivity.EarlyFinish = initialActivity.Cost;
-            SetEarly(initialActivity);
-        }
-    }
-
-    private static void SetEarly(Activity activity)
-    {
-        var completionTime = activity.EarlyFinish;
-        foreach (var activityDependency in activity.Dependencies)
-        {
-            if (completionTime >= activityDependency.EarlyStart)
-            {
-                activityDependency.EarlyStart = completionTime;
-                activityDependency.EarlyFinish = completionTime + activityDependency.Cost;
-            }
-            SetEarly(activityDependency);
-        }
     }
 }

--- a/src/NovoNordisk.CriticalPath/CriticalPathMethod.cs
+++ b/src/NovoNordisk.CriticalPath/CriticalPathMethod.cs
@@ -13,7 +13,7 @@ public interface ICriticalPathMethod
     /// <param name="activities">List of activities. Note that the HashSet is call-by-reference, so its properties will be modified by this function.</param>
     /// <returns>The activities on the critical path, ordered by their dependencies.</returns>
     List<Activity> Execute(HashSet<Activity> activities);
-}   
+}
 
 /// <summary>
 /// Implementation of the Critical Path Method.


### PR DESCRIPTION
The "old" implementation was not really optimized, leading to poor performance on "big" activity graphs (200+ nodes, 10.000+ edges). This implementation does a topological sort first, and then does linear iterations over the nodes.

With my local test use-case, runtimes dropped from roughly 15m to 0.1s.

Fixes #43  